### PR TITLE
Allow path parametrization from gui

### DIFF
--- a/godel_surface_detection/include/services/surface_blending_service.h
+++ b/godel_surface_detection/include/services/surface_blending_service.h
@@ -136,13 +136,14 @@ private:
   generateMotionLibrary(const godel_msgs::PathPlanningParameters& params);
 
 
-  bool generateProcessPath(const int& id, ProcessPathResult& result);
+  bool generateProcessPath(const int& id, const godel_msgs::PathPlanningParameters &params, ProcessPathResult& result);
 
 
   bool generateProcessPath(const int& id,
                            const std::string& name,
                            const pcl::PolygonMesh& mesh,
                            const godel_surface_detection::detection::CloudRGB::Ptr,
+                           const godel_msgs::PathPlanningParameters &params,
                            ProcessPathResult& result);
 
 

--- a/path_planning_plugins/include/path_planning_plugins/openveronoi_plugins.h
+++ b/path_planning_plugins/include/path_planning_plugins/openveronoi_plugins.h
@@ -51,12 +51,12 @@ namespace openveronoi
   class BlendPlanner : public path_planning_plugins_base::PathPlanningBase
   {
   private:
-    pcl::PolygonMesh mesh_;    
+    pcl::PolygonMesh mesh_;
 
   public:
     BlendPlanner() {}
     void init(pcl::PolygonMesh mesh);
-    bool generatePath(std::vector<geometry_msgs::PoseArray>& path);
+    bool generatePath(const godel_msgs::PathPlanningParameters &params, std::vector<geometry_msgs::PoseArray>& path);
   };
 
   class ScanPlanner : public path_planning_plugins_base::PathPlanningBase
@@ -67,7 +67,7 @@ namespace openveronoi
   public:
     ScanPlanner() {}
     void init(pcl::PolygonMesh mesh);
-    bool generatePath(std::vector<geometry_msgs::PoseArray>& path);
+    bool generatePath(const godel_msgs::PathPlanningParameters &params, std::vector<geometry_msgs::PoseArray>& path);
   };
 }
 }

--- a/path_planning_plugins/src/openveronoi/blend_planner.cpp
+++ b/path_planning_plugins/src/openveronoi/blend_planner.cpp
@@ -21,7 +21,7 @@ void openveronoi::BlendPlanner::init(pcl::PolygonMesh mesh)
   mesh_ = mesh;
 }
 
-bool openveronoi::BlendPlanner::generatePath(std::vector<geometry_msgs::PoseArray>& path)
+bool openveronoi::BlendPlanner::generatePath(const godel_msgs::PathPlanningParameters &params, std::vector<geometry_msgs::PoseArray>& path)
 {
   using godel_process_path::PolygonBoundaryCollection;
   using godel_process_path::PolygonBoundary;
@@ -31,22 +31,33 @@ bool openveronoi::BlendPlanner::generatePath(std::vector<geometry_msgs::PoseArra
   std::unique_ptr<mesh_importer::MeshImporter> mesh_importer_ptr(new mesh_importer::MeshImporter(false));
   ros::NodeHandle nh;
   ros::ServiceClient process_path_client = nh.serviceClient<godel_msgs::PathPlanning>(PATH_GENERATION_SERVICE);
-  godel_msgs::PathPlanningParameters params;
-  try
+  godel_msgs::PathPlanningParameters params_;
+  bool params_is_ok = params.tool_radius >= 0. &&                     /*tool must be real*/
+           params.margin >= 0. &&                          /*negative margin is dangerous*/
+           params.overlap < 2. * params.tool_radius &&           /*offset must increment inward*/
+           (params.tool_radius != 0. || params.overlap != 0.) && /*offset must be positive*/
+           params.traverse_height >= 0.;
+  if (!params_is_ok)
   {
-    nh.getParam(DISCRETIZATION, params.discretization);
-    nh.getParam(MARGIN, params.margin);
-    nh.getParam(OVERLAP, params.overlap);
-    nh.getParam(SAFE_TRAVERSE_HEIGHT, params.traverse_height);
-    nh.getParam(SCAN_WIDTH, params.scan_width);
-    nh.getParam(TOOL_RADIUS, params.tool_radius);
+    try
+    {
+      nh.getParam(DISCRETIZATION, params_.discretization);
+      nh.getParam(MARGIN, params_.margin);
+      nh.getParam(OVERLAP, params_.overlap);
+      nh.getParam(SAFE_TRAVERSE_HEIGHT, params_.traverse_height);
+      nh.getParam(SCAN_WIDTH, params_.scan_width);
+      ROS_ERROR_STREAM("params_.tool_radius = " << params_.tool_radius);
+      nh.getParam(TOOL_RADIUS, params_.tool_radius);
+      ROS_ERROR_STREAM("params_.tool_radius = " << params_.tool_radius);
+    }
+    catch(const std::exception& e)
+    {
+      ROS_ERROR_STREAM("Unable to populate path planning parameters" << e.what());
+      return false;
+    }
   }
-  catch(const std::exception& e)
-  {
-    ROS_ERROR_STREAM("Unable to populate path planning parameters" << e.what());
-    return false;
-  }
-
+  else
+    params_=params;
 
   // Calculate boundaries for a surface
   if (mesh_importer_ptr->calculateSimpleBoundary(mesh_))
@@ -60,7 +71,7 @@ bool openveronoi::BlendPlanner::generatePath(std::vector<geometry_msgs::PoseArra
 
     // Send request to blend path generation service
     godel_msgs::PathPlanning srv;
-    srv.request.params = params;
+    srv.request.params = params_;
     godel_process_path::utils::translations::godelToGeometryMsgs(srv.request.surface.boundaries, filtered_boundaries);
     tf::poseTFToMsg(tf::Transform::getIdentity(), srv.request.surface.pose);
 

--- a/path_planning_plugins_base/include/path_planning_plugins_base/path_planning_base.h
+++ b/path_planning_plugins_base/include/path_planning_plugins_base/path_planning_base.h
@@ -10,7 +10,7 @@ namespace path_planning_plugins_base
   {
   public:
     virtual void init(pcl::PolygonMesh mesh) = 0;
-    virtual bool generatePath(std::vector<geometry_msgs::PoseArray>& path) = 0;
+    virtual bool generatePath(const godel_msgs::PathPlanningParameters &params, std::vector<geometry_msgs::PoseArray>& path) = 0;
   };
 }
 


### PR DESCRIPTION
Changing parameters through the GUI has no effect on the path generation. Parameters are actually passed through the action server correctly but the blending_service_path_generation code is generating an empty PathPlanningParameters message instead of getting parameter from goal.
Can be tested launching the scan and plan application (any robots should be working) and changing path parameters in any of the blend panel.