### PR TITLE
Return Action result instead of Service result

### DIFF
--- a/godel_surface_detection/src/services/surface_blending_service.cpp
+++ b/godel_surface_detection/src/services/surface_blending_service.cpp
@@ -692,7 +692,7 @@ void SurfaceBlendingService::selectMotionPlansActionCallback(const godel_msgs::S
   if (trajectory_library_.get().find(goal_in->name) == trajectory_library_.get().end())
   {
     ROS_WARN_STREAM("Motion plan " << goal_in->name << " does not exist. Cannot execute.");
-    res.code = godel_msgs::SelectMotionPlanResponse::NO_SUCH_NAME;
+    res.code = godel_msgs::SelectMotionPlanResult::NO_SUCH_NAME;
     select_motion_plan_server_.setAborted(res);
     return;
   }


### PR DESCRIPTION
When selecting an action plan, if it doesn't exist, it should return the code defined within the [SelectMotionPlan Action Result](https://github.com/tecnalia-advancedmanufacturing-robotics/godel/blob/kinetic-devel/godel_msgs/action/SelectMotionPlan.action), instead it returns [SelectMotionPlan Service Response](https://github.com/tecnalia-advancedmanufacturing-robotics/godel/blob/kinetic-devel/godel_msgs/srv/SelectMotionPlan.srv).