### PR TITLE
Properly handle scan paramaters in scan planner plugin

### DIFF
--- a/path_planning_plugins/src/openveronoi/scan_planner.cpp
+++ b/path_planning_plugins/src/openveronoi/scan_planner.cpp
@@ -78,7 +78,7 @@ bool openveronoi::ScanPlanner::generatePath(const godel_msgs::PathPlanningParame
     geometry_msgs::PoseArray scan_poses;
 
     // 4 - Generate scan polygon boundary
-    PolygonBoundary scan_boundary = scan::generateProfilometerScanPath(filtered_boundaries.front(), params);
+    PolygonBoundary scan_boundary = scan::generateProfilometerScanPath(filtered_boundaries.front(), params_);
 
     // 5 - Get boundary pose eigen
     Eigen::Affine3d boundary_pose_eigen;


### PR DESCRIPTION
Scan planner plugin checks whether parameters are correct or not. In case they are not correct, parameters are loaded but not used. This fix, solved this issue.