### PR TITLE
Add service to set scan poses

### DIFF
--- a/godel_msgs/CMakeLists.txt
+++ b/godel_msgs/CMakeLists.txt
@@ -61,6 +61,7 @@ add_service_files(
   SurfaceBlendingParameters.srv
   TrajectoryExecution.srv
   TrajectoryPlanning.srv
+  SetScanPoses.srv
 )
 
 ## Generate added messages and services with any dependencies listed here

--- a/godel_msgs/srv/SetScanPoses.srv
+++ b/godel_msgs/srv/SetScanPoses.srv
@@ -1,0 +1,6 @@
+geometry_msgs/PoseArray poses
+---
+bool result
+
+
+

--- a/godel_surface_detection/include/scan/robot_scan.h
+++ b/godel_surface_detection/include/scan/robot_scan.h
@@ -65,6 +65,7 @@ public:
   void publish_scan_poses(std::string topic);
   MoveGroupPtr get_move_group();
   bool move_to_pose(geometry_msgs::Pose& target_pose);
+  void set_scan_poses(const geometry_msgs::PoseArray& poses);
   int scan(bool move_only = false);
 
   static void apply_trajectory_parabolic_time_parameterization(
@@ -87,6 +88,9 @@ protected:
 
 public: // parameters
   godel_msgs::RobotScanParameters params_;
+
+private:
+  bool using_custom_scan_poses_;
 };
 
 } /* namespace detection */

--- a/godel_surface_detection/include/services/surface_blending_service.h
+++ b/godel_surface_detection/include/services/surface_blending_service.h
@@ -31,6 +31,7 @@
 #include <godel_msgs/ProcessPlan.h>
 #include <godel_msgs/RenameSurface.h>
 #include <godel_msgs/ScanPlanParameters.h>
+#include <godel_msgs/SetScanPoses.h>
 
 #include <godel_msgs/BlendProcessPlanning.h>
 #include <godel_msgs/QuelltechProcessPlanning.h>
@@ -176,6 +177,9 @@ private:
   bool renameSurfaceCallback(godel_msgs::RenameSurface::Request& req,
                              godel_msgs::RenameSurface::Response& res);
 
+  bool setScanPosesCallback(godel_msgs::SetScanPoses::Request& req,
+                             godel_msgs::SetScanPoses::Response& res);
+
   void visualizePaths();
 
   void visualizePathPoses();
@@ -194,6 +198,7 @@ private:
   ros::ServiceServer get_motion_plans_server_;
   ros::ServiceServer load_save_motion_plan_server_;
   ros::ServiceServer rename_suface_server_;
+  ros::ServiceServer set_scan_poses_;
 
   // Services subscribed to by this class
   ros::ServiceClient process_path_client_;

--- a/godel_surface_detection/src/scan/robot_scan.cpp
+++ b/godel_surface_detection/src/scan/robot_scan.cpp
@@ -195,7 +195,6 @@ void RobotScan::set_scan_poses(const geometry_msgs::PoseArray& poses)
   {
     scan_traj_poses_.push_back(poses.poses[i]);
   }
-  //move_group_ptr_->setEndEffectorLink(params_.tcp_frame);
 }
 
 int RobotScan::scan(bool move_only)
@@ -249,7 +248,11 @@ int RobotScan::scan(bool move_only)
       auto rob_model = move_group_ptr_->getRobotModel();
       moveit::core::RobotState state (rob_model);
       state.setVariablePositions(current_state);
-      state.setFromIK(rob_model->getJointModelGroup(params_.group_name), trajectory_poses[i], params_.tcp_frame);
+      bool ik_res = state.setFromIK(rob_model->getJointModelGroup(params_.group_name), trajectory_poses[i], params_.tcp_frame);
+      if (!ik_res)
+      {
+        continue;
+      }
       std::vector<double> to_goto (state.getVariablePositions(), state.getVariablePositions() + current_state.size());
       move_group_ptr_->setJointValueTarget(to_goto);
 //      move_group_ptr_->setPoseTarget(trajectory_poses[i], params_.tcp_frame);

--- a/godel_surface_detection/src/services/surface_blending_service.cpp
+++ b/godel_surface_detection/src/services/surface_blending_service.cpp
@@ -26,6 +26,7 @@ const static std::string PATH_EXECUTION_SERVICE = "path_execution";
 const static std::string GET_MOTION_PLANS_SERVICE = "get_available_motion_plans";
 const static std::string SELECT_MOTION_PLAN_SERVICE = "select_motion_plan";
 const static std::string LOAD_SAVE_MOTION_PLAN_SERVICE = "load_save_motion_plan";
+const static std::string SET_SCAN_POSES_SERVICE = "set_scan_poses";
 
 const static std::string BLEND_PROCESS_EXECUTION_SERVICE = "blend_process_execution";
 const static std::string SCAN_PROCESS_EXECUTION_SERVICE = "scan_process_execution";
@@ -179,6 +180,10 @@ bool SurfaceBlendingService::init()
 
   rename_suface_server_ = nh_.advertiseService(RENAME_SURFACE_SERVICE,
                                               &SurfaceBlendingService::renameSurfaceCallback, this);
+
+  set_scan_poses_ = nh_.advertiseService(SET_SCAN_POSES_SERVICE,
+                                              &SurfaceBlendingService::setScanPosesCallback, this);
+
 
   // publishers
   selected_surf_changed_pub_ = nh_.advertise<godel_msgs::SelectedSurfacesChanged>(SELECTED_SURFACES_CHANGED_TOPIC, 1);
@@ -774,6 +779,14 @@ bool SurfaceBlendingService::renameSurfaceCallback(godel_msgs::RenameSurface::Re
 
   ROS_WARN_STREAM("Surface rename failed");
   return false;
+}
+
+bool SurfaceBlendingService::setScanPosesCallback(godel_msgs::SetScanPoses::Request& req,
+                                                   godel_msgs::SetScanPoses::Response& res)
+{
+  robot_scan_.set_scan_poses(req.poses);
+  res.result = true;
+  return true;
 }
 
 void SurfaceBlendingService::visualizePaths()

--- a/godel_surface_detection/src/services/surface_blending_service.cpp
+++ b/godel_surface_detection/src/services/surface_blending_service.cpp
@@ -181,7 +181,7 @@ bool SurfaceBlendingService::init()
   rename_suface_server_ = nh_.advertiseService(RENAME_SURFACE_SERVICE,
                                               &SurfaceBlendingService::renameSurfaceCallback, this);
 
-  set_scan_poses_ = nh_.advertiseService(SET_SCAN_POSES_SERVICE,
+  set_scan_poses_ = ph.advertiseService(SET_SCAN_POSES_SERVICE,
                                               &SurfaceBlendingService::setScanPosesCallback, this);
 
 


### PR DESCRIPTION
Adds a service to choose different scan poses.
If no service is called, scan poses calculated based on some parameters stored in parameter server. 
This process is not dynamic, so I added a service to include an option to set desired scan poses.
For trajectory generation between poses, the same method has been kept.

