### PR TITLE
Use KSearch algorithm instread of RadiusSearch for surface segmenetation

### DIFF
--- a/godel_surface_detection/src/segmentation/surface_segmentation.cpp
+++ b/godel_surface_detection/src/segmentation/surface_segmentation.cpp
@@ -641,8 +641,8 @@ void SurfaceSegmentation::computeNormals()
   ne.setInputCloud (input_cloud_);
   pcl::search::KdTree<pcl::PointXYZRGB>::Ptr tree (new pcl::search::KdTree<pcl::PointXYZRGB> ());
   ne.setSearchMethod (tree);
-  ne.setRadiusSearch(0.025);
-//  ne.setKSearch (100);
+  //ne.setRadiusSearch(0.025);
+  ne.setKSearch (250);
 
   // Estimate the normals
   ne.compute (*normals_);


### PR DESCRIPTION
Use KSearch algorithm instread of RadiusSearch for surface segmenetation. Has better behavior, and cleaner surface detection.