### PR TITLE
Add removeNan function for downsampled pointcloud

### DIFF
--- a/godel_surface_detection/include/segmentation/surface_segmentation.h
+++ b/godel_surface_detection/include/segmentation/surface_segmentation.h
@@ -155,6 +155,7 @@ public:
 private:
   /** @brief remove any NAN points, otherwise many algorithms fail */
   void removeNans();
+  void removeNansFromDownSampledCloud();
 
   /** @brief compute the normals and store in normals_, this is requried for both segmentation and meshing*/
   void computeNormals();

--- a/godel_surface_detection/src/segmentation/surface_segmentation.cpp
+++ b/godel_surface_detection/src/segmentation/surface_segmentation.cpp
@@ -60,6 +60,8 @@ void SurfaceSegmentation::setInputCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr i
   vg.setLeafSize (DOWNSAMPLING_LEAF,DOWNSAMPLING_LEAF,DOWNSAMPLING_LEAF);
   vg.filter(*input_cloud_downsampled_);
 
+  removeNansFromDownSampledCloud();
+
   // create kdtree for speeding up search queries
   kd_tree_.reset(new pcl::search::KdTree<pcl::PointXYZ>());
   kd_tree_->setInputCloud(input_cloud_downsampled_);
@@ -627,6 +629,12 @@ void SurfaceSegmentation::removeNans()
 {
   std::vector<int> indices;
   pcl::removeNaNFromPointCloud (*input_cloud_, *input_cloud_, indices);
+}
+
+void SurfaceSegmentation::removeNansFromDownSampledCloud()
+{
+  std::vector<int> indices;
+  pcl::removeNaNFromPointCloud (*input_cloud_downsampled_, *input_cloud_downsampled_, indices);
 }
 
 


### PR DESCRIPTION
pcl's radius search algorithm fails if point with NaN coordinates remain in the used point cloud